### PR TITLE
Fixes and cleanups for multi-byte to wide-char conversions and begin date override

### DIFF
--- a/WOLFSSL/WOLFSSL.vcproj
+++ b/WOLFSSL/WOLFSSL.vcproj
@@ -231,7 +231,7 @@
 			OutputDirectory="$(SolutionDir)Pocket PC 2003 (ARMV4)\$(ConfigurationName)"
 			IntermediateDirectory="Pocket PC 2003 (ARMV4)\$(ConfigurationName)"
 			ConfigurationType="1"
-			CharacterSet="2"
+			CharacterSet="1"
 			WholeProgramOptimization="1"
 			>
 			<Tool
@@ -271,6 +271,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
+				AdditionalDependencies="Ws2.lib Coredll.lib"
 				GenerateDebugInformation="true"
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"

--- a/WOLFSSL/src/ssl_misc.c
+++ b/WOLFSSL/src/ssl_misc.c
@@ -470,7 +470,9 @@ static int wolfssl_read_file_static(const char* fname, StaticBuffer* content,
         ret = WOLFSSL_BAD_FILE;
     }
     /* Open file for reading. */
+    WOLFSSL_MSG(fname);
     if ((ret == 0) && ((file = XFOPEN(fname, "rb")) == XBADFILE)) {
+        WOLFSSL_MSG("Failed to open file");
         ret = WOLFSSL_BAD_FILE;
     }
     if (ret == 0) {
@@ -484,6 +486,7 @@ static int wolfssl_read_file_static(const char* fname, StaticBuffer* content,
     /* Read data from file. */
     if ((ret == 0) && ((size_t)XFREAD(content->buffer, 1, (size_t)sz, file) !=
             (size_t)sz)) {
+        WOLFSSL_MSG("Failed to read file");
         ret = WOLFSSL_BAD_FILE;
     }
 

--- a/WOLFSSL/user_settings.h
+++ b/WOLFSSL/user_settings.h
@@ -27,8 +27,10 @@
 #define USE_WOLF_STRTOK
 #define XSNPRINTF StringCbPrintfA
 #include <string.h> /* for strcpy_s */
+#define NO_THEAD_LS
 
-
+/* Enables the X509_STORE_CTX_get_error function required to get error code */
+#define OPENSSL_EXTRA_X509_SMALL
 
 /* Features */
 #define WOLFSSL_TLS13
@@ -43,8 +45,12 @@
     #define WOLFSSL_KEY_GEN
 #endif
 
-#if 1 /* debug messages - logging */
+#if 0 /* debug messages - logging */
     #define DEBUG_WOLFSSL
+	#define WOLFSSL_DEBUG_MEMORY
+	#define WOLFSSL_DEBUG_MEMORY_PRINT
+	#define WOLFSSL_TRACK_MEMORY
+	#define SINGLE_THREADED
 #endif
 
 /* TLS Extensions */

--- a/WOLFSSL/wolfssl/wolfcrypt/mem_track.h
+++ b/WOLFSSL/wolfssl/wolfcrypt/mem_track.h
@@ -177,7 +177,7 @@ static WC_INLINE void* TrackMalloc(size_t sz)
     (void)line;
 #endif
 #endif
-#if defined(DO_MEM_LIST) || defined(DO_MEM_STATS)
+#if !defined(SINGLE_THREADED) && (defined(DO_MEM_LIST) || defined(DO_MEM_STATS))
     if (pthread_mutex_lock(&memLock) == 0)
     {
 #endif
@@ -223,7 +223,7 @@ static WC_INLINE void* TrackMalloc(size_t sz)
         ourMemList.tail = header;      /* add to the end either way */
         ourMemList.count++;
 #endif
-#if defined(DO_MEM_LIST) || defined(DO_MEM_STATS)
+#if !defined(SINGLE_THREADED) && (defined(DO_MEM_LIST) || defined(DO_MEM_STATS))
         pthread_mutex_unlock(&memLock);
     }
 #endif /* DO_MEM_LIST */
@@ -250,7 +250,7 @@ static WC_INLINE void TrackFree(void* ptr)
     header = &mt->u.hint;
     sz = header->thisSize;
 
-#if defined(DO_MEM_LIST) || defined(DO_MEM_STATS)
+#if !defined(SINGLE_THREADED) && (defined(DO_MEM_LIST) || defined(DO_MEM_STATS))
     if (pthread_mutex_lock(&memLock) == 0)
     {
 #endif
@@ -284,7 +284,7 @@ static WC_INLINE void TrackFree(void* ptr)
         ourMemList.count--;
 #endif
 
-#if defined(DO_MEM_LIST) || defined(DO_MEM_STATS)
+#if !defined(SINGLE_THREADED) && (defined(DO_MEM_LIST) || defined(DO_MEM_STATS))
         pthread_mutex_unlock(&memLock);
     }
 #endif

--- a/WinCE/WOLFSSL/WolfSSLClient.cs
+++ b/WinCE/WOLFSSL/WolfSSLClient.cs
@@ -15,6 +15,8 @@ namespace NETtime.WinCE
 {
     public static class WOLFSSLWrapper
     {
+        private static wolfssl.WOLFSSL_ALERT_HISTORY myHistory = new wolfssl.WOLFSSL_ALERT_HISTORY();
+
         /// <summary>
         /// Verification callback
         /// </summary>
@@ -24,9 +26,8 @@ namespace NETtime.WinCE
         {
             int verify = preverify;
             int error = wolfssl.X509_STORE_CTX_get_error(x509_ctx);
-            const int ASN_BEFORE_DATE_E = -150;  /* ASN date error, current date before */
-
-            if (error == ASN_BEFORE_DATE_E) {
+            if (error == wolfcrypt.ASN_BEFORE_DATE_E)
+            {
                 Console.WriteLine("Overriding before date error");
                 verify = 1; /* override error */
             }
@@ -49,8 +50,42 @@ namespace NETtime.WinCE
         /// <param name="msg">message to log</param>
         public static void standard_log(int lvl, string msg)
         {
+            /* try multi-byte and fall back to msg if invalid */
             string logMsg = wolfssl.MultiByteToWideChar(msg);
+            if (logMsg.Length < msg.Length / 2)
+            {
+                /* not multi-byte. internal log() are already wide char */
+                logMsg = msg;
+            }
             Console.WriteLine(logMsg);
+        }
+
+        private static void show_alert_history_code(wolfssl.WOLFSSL_ALERT h, string m)
+        {
+            /* VS initializes .code and .level to zero; wolfSSL sets to -1 until there's a valid value. */
+            if ((h.code > 0) || (h.level > 0))
+            {
+                Console.WriteLine(m + " code:  " + h.code.ToString());
+            }
+            if ((h.code > 0) || (h.level > 0))
+            {
+                Console.WriteLine(m + " level: " + h.level.ToString());
+            }
+        }
+
+        private static void show_alert_history(IntPtr ssl)
+        {
+            int ret = 0;
+            ret = wolfssl.get_alert_history(ssl, ref myHistory);
+            if (ret == wolfssl.SUCCESS)
+            {
+                show_alert_history_code(myHistory.last_tx, "myHistory last_tx");
+                show_alert_history_code(myHistory.last_rx, "myHistory last_rx");
+            }
+            else
+            {
+                Console.WriteLine("Failed: call to get_alert_history failed with error " + ret.ToString());
+            }
         }
 
         public static void ConnectToServer()
@@ -146,6 +181,7 @@ namespace NETtime.WinCE
             {
                 /* get and print out the error */
                 Console.WriteLine("TLS Connect failed: " + wolfssl.get_error(ssl));
+                show_alert_history(ssl);
                 tcp.Close();
                 clean(ssl, ctx);
                 return;

--- a/WinCE/WOLFSSL/WolfSSLClient.cs
+++ b/WinCE/WOLFSSL/WolfSSLClient.cs
@@ -15,11 +15,24 @@ namespace NETtime.WinCE
 {
     public static class WOLFSSLWrapper
     {
+        /// <summary>
+        /// Verification callback
+        /// </summary>
+        /// <param name="preverify">1=Verify Okay, 0=Failure</param>
+        /// <param name="x509_ctx">Certificate in WOLFSSL_X509_STORE_CTX format</param>
         private static int myVerify(int preverify, IntPtr x509_ctx)
         {
-            /* Use the provided verification */
+            int verify = preverify;
+            int error = wolfssl.X509_STORE_CTX_get_error(x509_ctx);
+            const int ASN_BEFORE_DATE_E = -150;  /* ASN date error, current date before */
+
+            if (error == ASN_BEFORE_DATE_E) {
+                Console.WriteLine("Overriding before date error");
+                verify = 1; /* override error */
+            }
+
             /* Can optionally override failures by returning non-zero value */
-            return preverify;
+            return verify;
         }
 
         private static void clean(IntPtr ssl, IntPtr ctx)

--- a/WinCE/WOLFSSL/WolfSSLClient.cs
+++ b/WinCE/WOLFSSL/WolfSSLClient.cs
@@ -36,12 +36,27 @@ namespace NETtime.WinCE
         /// <param name="msg">message to log</param>
         public static void standard_log(int lvl, string msg)
         {
-            Console.WriteLine(wolfssl.UnicodeToAscii(msg));
+            string logMsg = wolfssl.MultiByteToWideChar(msg);
+            Console.WriteLine(logMsg);
         }
 
         public static void ConnectToServer()
         {
             StringBuilder caCert = new StringBuilder(Utility.LocalPath + "\\Cert\\ca-cert.pem");
+
+            /* string conversion tests */
+            /* WinCE:       using Unicode 16-bit
+             * wolfSSL DLL: using multi-byte (8-bit) */
+            string caCert1 = Path.GetFullPath("\\Cert\\ca-cert.pem");
+            string uCaCert1 = wolfssl.WideCharToMultiByte(caCert1);
+            string bCaCert1 = wolfssl.MultiByteToWideChar(uCaCert1);
+            Console.WriteLine("Before: " + caCert1 + ", After: " + bCaCert1);
+            /* odd length test */
+            string caCert2 = Path.GetFullPath("\\Certs\\ca-cert.pem");
+            string uCaCert2 = wolfssl.WideCharToMultiByte(caCert2);
+            string bCaCert2 = wolfssl.MultiByteToWideChar(uCaCert2);
+            Console.WriteLine("Before: " + caCert2 + ", After: " + bCaCert2);
+
             IntPtr ssl = IntPtr.Zero;
             IntPtr ctx = IntPtr.Zero;
 
@@ -50,8 +65,8 @@ namespace NETtime.WinCE
             string host = "stratus-clock-n2a.cloud.paychex.com";
             int port = 443;
 
-            //Console.WriteLine("Enabling Debug");
-            //wolfssl.Debugging_ON();
+            Console.WriteLine("Enabling Debug");
+            wolfssl.Debugging_ON();
 
             // example of function used for setting logging
             Console.WriteLine("Setting Logging");
@@ -122,6 +137,7 @@ namespace NETtime.WinCE
                 clean(ssl, ctx);
                 return;
             }
+            Console.WriteLine("TLS Connected " + wolfssl.get_error(ssl));
             Console.WriteLine("TLS Connected: version is " + wolfssl.get_version(ssl));
             Console.WriteLine("TLS Cipher Suite is " + wolfssl.get_current_cipher(ssl));
 

--- a/wolfSSLWrapper/X509.cs
+++ b/wolfSSLWrapper/X509.cs
@@ -19,10 +19,18 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+
+/* CE Not always reliably detected. Define our own WindowsCE as needed. */
+#if _WIN32_WCE || WINCE || PocketPC
+    /* WindowsCE should have been defined in the Project and user_settings.h  */
+    #if !WindowsCE
+        #define WindowsCE
+    #endif
+#endif
+
+
 using System;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading;
 
 namespace wolfSSL.CSharp
 {

--- a/wolfSSLWrapper/wolfCrypt.cs
+++ b/wolfSSLWrapper/wolfCrypt.cs
@@ -19,15 +19,36 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+
+/* CE Not always reliably detected. Define our own WindowsCE as needed. */
+#if _WIN32_WCE || WINCE || PocketPC
+    /* WindowsCE should have been defined in the Project and user_settings.h  */
+    #if !WindowsCE
+        #define WindowsCE
+    #endif
+#endif
+
+
 using System;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography;
 using System.Text;
+#if WindowsCE
+    using wolfSSL.CSharp;
+#else
+    using static wolfSSL.CSharp.wolfssl;
+#endif
 
 namespace wolfSSL.CSharp
 {
     public class wolfcrypt
     {
+        /* Ensure CPU architecture of .cs files matches wolfssl.dll
+         *
+         * See the x64 wolfssl.dll file in
+         *   [WOLFSSL_ROOT]\wrapper\CSharp\Debug\x64\wolfssl.dll
+         * not AnyCPU
+         *   [WOLFSSL_ROOT]\wrapper\CSharp\DLL Debug\wolfssl.dll
+         */
         private const string wolfssl_dll = "wolfssl.dll";
 
         /********************************
@@ -511,38 +532,11 @@ namespace wolfSSL.CSharp
 #if WindowsCE
         [DllImport(wolfssl_dll)]
         private extern static IntPtr wc_GetErrorString(int error);
-        public delegate void loggingCb(int lvl, string msg);
+        /* No Windows CE decorator for logging call-back */
 #else
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private extern static IntPtr wc_GetErrorString(int error);
-        public delegate void loggingCb(int lvl, StringBuilder msg);
 #endif
-        private static loggingCb internal_log;
-
-        /// <summary>
-        /// Log a message to set logging function
-        /// </summary>
-        /// <param name="lvl">Level of log message</param>
-        /// <param name="msg">Message to log</param>
-#if WindowsCE
-        private static void log(int lvl, string msg)
-        {
-            /* if log is not set then print nothing */
-            if (internal_log == null)
-                return;
-            internal_log(lvl, msg);
-        }
-#else
-        private static void log(int lvl, string msg)
-        {
-            /* if log is not set then print nothing */
-            if (internal_log == null)
-                return;
-            StringBuilder ptr = new StringBuilder(msg);
-            internal_log(lvl, ptr);
-        }
-#endif
-
 
         /********************************
          * Enum types from wolfSSL library
@@ -566,11 +560,29 @@ namespace wolfSSL.CSharp
         public static readonly int AES_BLOCK_SIZE = 16;
 
         /* Error codes */
-        public static readonly int SUCCESS = 0;
-        public static readonly int SIG_VERIFY_E = -229;    /* wolfcrypt signature verify error */
-        public static readonly int MEMORY_E = -125;        /* Out of memory error */
-        public static readonly int EXCEPTION_E = -1;
-        public static readonly int BUFFER_E = -131;        /* RSA buffer error, output too small/large */
+        public static readonly int SUCCESS            = 0;
+        public static readonly int EXCEPTION_E        = -1;
+        public static readonly int MEMORY_E           = -125;  /* Out of memory error */
+        public static readonly int BUFFER_E           = -131;  /* RSA buffer error, output too small/large */
+        public static readonly int ASN_PARSE_E        = -140;  /* ASN parsing error, invalid input */
+        public static readonly int ASN_VERSION_E      = -141;  /* ASN version error, invalid number */
+        public static readonly int ASN_GETINT_E       = -142;  /* ASN get big int error, invalid data */
+        public static readonly int ASN_RSA_KEY_E      = -143;  /* ASN key init error, invalid input */
+        public static readonly int ASN_OBJECT_ID_E    = -144;  /* ASN object id error, invalid id */
+        public static readonly int ASN_TAG_NULL_E     = -145;  /* ASN tag error, not null */
+        public static readonly int ASN_EXPECT_0_E     = -146;  /* ASN expect error, not zero */
+        public static readonly int ASN_BITSTR_E       = -147;  /* ASN bit string error, wrong id */
+        public static readonly int ASN_UNKNOWN_OID_E  = -148;  /* ASN oid error, unknown sum id */
+        public static readonly int ASN_DATE_SZ_E      = -149;  /* ASN date error, bad size */
+        public static readonly int ASN_BEFORE_DATE_E  = -150;  /* ASN date error, current date before */
+        public static readonly int ASN_AFTER_DATE_E   = -151;  /* ASN date error, current date after */
+        public static readonly int ASN_SIG_OID_E      = -152;  /* ASN signature error, mismatched oid */
+        public static readonly int ASN_TIME_E         = -153;  /* ASN time error, unknown time type */
+        public static readonly int ASN_INPUT_E        = -154;  /* ASN input error, not enough data */
+        public static readonly int ASN_SIG_CONFIRM_E  = -155;  /* ASN sig error, confirm failure */
+        public static readonly int ASN_SIG_HASH_E     = -156;  /* ASN sig error, unsupported hash type */
+        public static readonly int ASN_SIG_KEY_E      = -157;  /* ASN sig error, unsupported key type */
+        public static readonly int SIG_VERIFY_E       = -229;  /* wolfcrypt signature verify error */
 
 
         /***********************************************************************
@@ -590,7 +602,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "wolfCrypt init error " + e.ToString());
+                wolfssl.log(ERROR_LOG, "wolfCrypt init error " + e.ToString());
                 ret = EXCEPTION_E;
             }
             return ret;
@@ -609,7 +621,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "wolfCrypt cleanup error " + e.ToString());
+                wolfssl.log(ERROR_LOG, "wolfCrypt cleanup error " + e.ToString());
                 ret = EXCEPTION_E;
             }
             return ret;
@@ -637,7 +649,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "random new exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "random new exception " + e.ToString());
                 rng = IntPtr.Zero;
             }
 
@@ -684,7 +696,7 @@ namespace wolfSSL.CSharp
                     }
                     else
                     {
-                        log(ERROR_LOG, "random generate block error " + ret + ": " + GetError(ret));
+                        wolfssl.log(ERROR_LOG, "random generate block error " + ret + ": " + GetError(ret));
                     }
                     Marshal.FreeHGlobal(data);
                 }
@@ -695,7 +707,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "random generate block exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "random generate block exception " + e.ToString());
                 ret = EXCEPTION_E;
             }
 
@@ -753,7 +765,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECC make key exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECC make key exception " + e.ToString());
 
                 EccFreeKey(key);
                 key = IntPtr.Zero;
@@ -777,7 +789,7 @@ namespace wolfSSL.CSharp
                 /* Check */
                 if (key == IntPtr.Zero)
                 {
-                    log(ERROR_LOG, "Invalid key or rng pointer.");
+                    wolfssl.log(ERROR_LOG, "Invalid key or rng pointer.");
                     return MEMORY_E;
                 }
 
@@ -785,12 +797,12 @@ namespace wolfSSL.CSharp
                 ret = wc_ecc_set_rng(key, rng);
                 if (ret != 0)
                 {
-                    log(ERROR_LOG, "ECC set rng failed returned:" + ret);
+                    wolfssl.log(ERROR_LOG, "ECC set rng failed returned:" + ret);
                 }
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECC set rng exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECC set rng exception " + e.ToString());
             }
 
             return ret;
@@ -827,7 +839,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECC import key exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECC import key exception " + e.ToString());
                 EccFreeKey(key); /* make sure its free'd */
                 key = IntPtr.Zero;
             }
@@ -878,7 +890,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECC sign exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECC sign exception: " + e.ToString());
                 ret = EXCEPTION_E;
             }
             finally
@@ -925,7 +937,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECC verify exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECC verify exception " + e.ToString());
                 ret = EXCEPTION_E;
             }
             finally
@@ -952,19 +964,19 @@ namespace wolfSSL.CSharp
             {
                 int bufferSize = wc_EccPrivateKeyToDer(key, null, 0);
                 if (bufferSize < 0) {
-                    log(ERROR_LOG, "ECC private key get size failed " + bufferSize.ToString());
+                    wolfssl.log(ERROR_LOG, "ECC private key get size failed " + bufferSize.ToString());
                     return bufferSize;
                 }
                 derKey = new byte[bufferSize];
                 ret = wc_EccPrivateKeyToDer(key, derKey, (uint)bufferSize);
                 if (ret < 0)
                 {
-                    log(ERROR_LOG, "ECC private key to der failed " + ret.ToString());
+                    wolfssl.log(ERROR_LOG, "ECC private key to der failed " + ret.ToString());
                 }
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECC export private exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECC export private exception " + e.ToString());
                 ret = EXCEPTION_E;
             }
 
@@ -986,19 +998,19 @@ namespace wolfSSL.CSharp
             {
                 int bufferSize = wc_EccPublicKeyToDer(key, null, 0, includeCurve ? 1 : 0);
                 if (bufferSize < 0) {
-                    log(ERROR_LOG, "ECC public key get size failed " + bufferSize.ToString());
+                    wolfssl.log(ERROR_LOG, "ECC public key get size failed " + bufferSize.ToString());
                     return bufferSize;
                 }
                 derKey = new byte[bufferSize];
                 ret = wc_EccPublicKeyToDer(key, derKey, (uint)bufferSize, includeCurve ? 1 : 0);
                 if (ret < 0)
                 {
-                    log(ERROR_LOG, "ECC public key to der failed " + ret.ToString());
+                    wolfssl.log(ERROR_LOG, "ECC public key to der failed " + ret.ToString());
                 }
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECC export public exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECC export public exception " + e.ToString());
                 ret = EXCEPTION_E;
             }
 
@@ -1031,7 +1043,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECC import public key exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECC import public key exception " + e.ToString());
                 EccFreeKey(key);
                 key = IntPtr.Zero;
             }
@@ -1074,12 +1086,12 @@ namespace wolfSSL.CSharp
                 ctx = wc_ecc_ctx_new_ex(flags, rng, heap);
                 if (ctx == IntPtr.Zero)
                 {
-                    log(ERROR_LOG, "ECIES context creation with custom heap failed: returned IntPtr.Zero");
+                    wolfssl.log(ERROR_LOG, "ECIES context creation with custom heap failed: returned IntPtr.Zero");
                 }
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECIES context creation with custom heap failed: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECIES context creation with custom heap failed: " + e.ToString());
                 return IntPtr.Zero;
             }
 
@@ -1102,7 +1114,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECIES context reset exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECIES context reset exception: " + e.ToString());
                 ret = EXCEPTION_E;
             }
 
@@ -1127,7 +1139,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECIES set algorithm exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECIES set algorithm exception: " + e.ToString());
                 ret = EXCEPTION_E;
             }
 
@@ -1149,7 +1161,7 @@ namespace wolfSSL.CSharp
                 /* Check ctx */
                 if (ctx == IntPtr.Zero)
                 {
-                    log(ERROR_LOG, "Invalid ECIES context pointer.");
+                    wolfssl.log(ERROR_LOG, "Invalid ECIES context pointer.");
                     return null;
                 }
 
@@ -1157,7 +1169,7 @@ namespace wolfSSL.CSharp
                 saltPtr = wc_ecc_ctx_get_own_salt(ctx);
                 if (saltPtr == IntPtr.Zero)
                 {
-                    log(ERROR_LOG, "Failed to get own salt.");
+                    wolfssl.log(ERROR_LOG, "Failed to get own salt.");
                     return null;
                 }
 
@@ -1167,7 +1179,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECIES get own salt exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECIES get own salt exception: " + e.ToString());
                 return null;
             }
             finally
@@ -1201,7 +1213,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECIES set peer salt exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECIES set peer salt exception: " + e.ToString());
                 ret = EXCEPTION_E;
             }
             finally
@@ -1237,7 +1249,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECIES set own salt exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECIES set own salt exception: " + e.ToString());
                 ret = EXCEPTION_E;
             }
             finally
@@ -1273,7 +1285,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECIES set KDF salt exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECIES set KDF salt exception: " + e.ToString());
                 ret = EXCEPTION_E;
             }
             finally
@@ -1307,7 +1319,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECIES set info exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECIES set info exception: " + e.ToString());
                 ret = EXCEPTION_E;
             }
             finally
@@ -1351,7 +1363,7 @@ namespace wolfSSL.CSharp
                 ret = wc_ecc_encrypt(privKey, pubKey, msgPtr, msgSz, outBufferPtr, outSz, ctx);
                 if (ret < 0)
                 {
-                    log(ERROR_LOG, "Failed to encrypt message using ECIES. Error code: " + ret);
+                    wolfssl.log(ERROR_LOG, "Failed to encrypt message using ECIES. Error code: " + ret);
                 }
                 /* Output actual output buffer length */
                 if (ret == 0)
@@ -1369,7 +1381,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECIES encryption exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECIES encryption exception: " + e.ToString());
                 ret = EXCEPTION_E;
             }
             finally
@@ -1415,7 +1427,7 @@ namespace wolfSSL.CSharp
                 ret = wc_ecc_decrypt(privKey, pubKey, msgPtr, msgSz, outBufferPtr, outSz, ctx);
                 if (ret < 0)
                 {
-                    log(ERROR_LOG, "Failed to decrypt message using ECIES. Error code: " + ret);
+                    wolfssl.log(ERROR_LOG, "Failed to decrypt message using ECIES. Error code: " + ret);
                 }
                 /* Output actual output buffer length */
                 if (ret == 0)
@@ -1433,7 +1445,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECIES decryption exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECIES decryption exception: " + e.ToString());
                 return EXCEPTION_E;
             }
             finally
@@ -1544,7 +1556,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ECC shared secret exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ECC shared secret exception " + e.ToString());
                 ret = EXCEPTION_E;
             }
 
@@ -1597,7 +1609,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "RSA make key exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "RSA make key exception " + e.ToString());
                 if (rng != IntPtr.Zero) RandomFree(rng);
                 if (key != IntPtr.Zero) RsaFreeKey(key);
                 key = IntPtr.Zero;
@@ -1642,7 +1654,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "RSA make key exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "RSA make key exception " + e.ToString());
                 RsaFreeKey(key); /* make sure its free'd */
                 key = IntPtr.Zero;
             }
@@ -1729,7 +1741,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "RSA verify exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "RSA verify exception: " + e.ToString());
                 ret = EXCEPTION_E;
             }
             finally
@@ -1840,7 +1852,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ED25519 make key exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ED25519 make key exception: " + e.ToString());
                 ret = EXCEPTION_E;
             }
             finally
@@ -1928,7 +1940,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ED25519 verify exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ED25519 verify exception: " + e.ToString());
                 ret = EXCEPTION_E;
             }
             finally
@@ -1967,7 +1979,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ED25519 private key decode exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ED25519 private key decode exception: " + e.ToString());
                 if (key != IntPtr.Zero) Ed25519FreeKey(key);
                 key = IntPtr.Zero;
             }
@@ -2001,7 +2013,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ED25519 public key decode exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ED25519 public key decode exception: " + e.ToString());
                 if (key != IntPtr.Zero) Ed25519FreeKey(key);
                 key = IntPtr.Zero;
             }
@@ -2026,7 +2038,7 @@ namespace wolfSSL.CSharp
                 int len = wc_Ed25519KeyToDer(key, null, 0);
                 if (len < 0)
                 {
-                    log(ERROR_LOG, "Failed to determine length. Error code: " + len);
+                    wolfssl.log(ERROR_LOG, "Failed to determine length. Error code: " + len);
                     return len;
                 }
 
@@ -2035,13 +2047,13 @@ namespace wolfSSL.CSharp
 
                 if (ret < 0)
                 {
-                    log(ERROR_LOG, "Failed to export ED25519 private key to DER format. Error code: " + ret);
+                    wolfssl.log(ERROR_LOG, "Failed to export ED25519 private key to DER format. Error code: " + ret);
                     return ret;
                 }
             }
             catch(Exception e)
             {
-                log(ERROR_LOG, "ED25519 export private key to DER exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ED25519 export private key to DER exception: " + e.ToString());
                 return EXCEPTION_E;
             }
 
@@ -2065,7 +2077,7 @@ namespace wolfSSL.CSharp
                 int len = wc_Ed25519PrivateKeyToDer(key, null, 0);
                 if (len < 0)
                 {
-                    log(ERROR_LOG, "Failed to determine length. Error code: " + len);
+                    wolfssl.log(ERROR_LOG, "Failed to determine length. Error code: " + len);
                     return len;
                 }
 
@@ -2074,13 +2086,13 @@ namespace wolfSSL.CSharp
 
                 if (ret < 0)
                 {
-                    log(ERROR_LOG, "Failed to export ED25519 private key to DER format. Error code: " + ret);
+                    wolfssl.log(ERROR_LOG, "Failed to export ED25519 private key to DER format. Error code: " + ret);
                     return ret;
                 }
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ED25519 export private key to DER exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ED25519 export private key to DER exception: " + e.ToString());
                 return EXCEPTION_E;
             }
 
@@ -2105,7 +2117,7 @@ namespace wolfSSL.CSharp
                 int len = wc_Ed25519PublicKeyToDer(key, null, 0, 1);
                 if (len < 0)
                 {
-                    log(ERROR_LOG, "Failed to determine length. Error code: " + len);
+                    wolfssl.log(ERROR_LOG, "Failed to determine length. Error code: " + len);
                     return len;
                 }
 
@@ -2113,13 +2125,13 @@ namespace wolfSSL.CSharp
                 ret = wc_Ed25519PublicKeyToDer(key, pubKey, (uint)pubKey.Length, includeAlg ? 1 : 0);
                 if (ret < 0)
                 {
-                    log(ERROR_LOG, "Failed to export ED25519 public key to DER format. Error code: " + ret);
+                    wolfssl.log(ERROR_LOG, "Failed to export ED25519 public key to DER format. Error code: " + ret);
                     return ret;
                 }
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "ED25519 export public key to DER exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "ED25519 export public key to DER exception: " + e.ToString());
                 return EXCEPTION_E;
             }
 
@@ -2367,7 +2379,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "Curve25519 make key exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "Curve25519 make key exception: " + e.ToString());
                 ret = EXCEPTION_E;
             }
             finally
@@ -2410,7 +2422,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "Curve25519 private key decode exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "Curve25519 private key decode exception: " + e.ToString());
                 if (key != IntPtr.Zero) Curve25519FreeKey(key);
                 key = IntPtr.Zero;
             }
@@ -2444,7 +2456,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "Curve25519 public key decode exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "Curve25519 public key decode exception: " + e.ToString());
                 if (key != IntPtr.Zero) Curve25519FreeKey(key);
                 key = IntPtr.Zero;
             }
@@ -2469,7 +2481,7 @@ namespace wolfSSL.CSharp
                 int len = wc_Curve25519PrivateKeyToDer(key, null, 0);
                 if (len < 0)
                 {
-                    log(ERROR_LOG, "Failed to determine length. Error code: " + len);
+                    wolfssl.log(ERROR_LOG, "Failed to determine length. Error code: " + len);
                     return len;
                 }
 
@@ -2478,13 +2490,13 @@ namespace wolfSSL.CSharp
 
                 if (ret < 0)
                 {
-                    log(ERROR_LOG, "Failed to export Curve25519 private key to DER format. Error code: " + ret);
+                    wolfssl.log(ERROR_LOG, "Failed to export Curve25519 private key to DER format. Error code: " + ret);
                     return ret;
                 }
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "CURVE25519 export private key to DER exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "CURVE25519 export private key to DER exception: " + e.ToString());
                 return EXCEPTION_E;
             }
 
@@ -2509,7 +2521,7 @@ namespace wolfSSL.CSharp
                 int len = wc_Curve25519PublicKeyToDer(key, null, 0, 1);
                 if (len < 0)
                 {
-                    log(ERROR_LOG, "Failed to determine length. Error code: " + len);
+                    wolfssl.log(ERROR_LOG, "Failed to determine length. Error code: " + len);
                     return len;
                 }
 
@@ -2517,12 +2529,12 @@ namespace wolfSSL.CSharp
                 ret = wc_Curve25519PublicKeyToDer(key, derKey, (uint)derKey.Length, includeAlg ? 1 : 0);
                 if (ret < 0)
                 {
-                    log(ERROR_LOG, "Failed to export Curve25519 public key to DER format. Error code: " + ret);
+                    wolfssl.log(ERROR_LOG, "Failed to export Curve25519 public key to DER format. Error code: " + ret);
                 }
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "Curve25519 export public key to DER exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "Curve25519 export public key to DER exception: " + e.ToString());
                 ret = EXCEPTION_E;
             }
 
@@ -2567,7 +2579,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "Curve25519 shared secret exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "Curve25519 shared secret exception " + e.ToString());
                 ret = EXCEPTION_E;
             }
 
@@ -2596,7 +2608,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "Curve25519 import private key exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "Curve25519 import private key exception " + e.ToString());
                 if (key != IntPtr.Zero) Marshal.FreeHGlobal(key);
                 key = IntPtr.Zero;
             }
@@ -2626,7 +2638,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "Curve25519 import public key exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "Curve25519 import public key exception " + e.ToString());
                 if (key != IntPtr.Zero) Marshal.FreeHGlobal(key);
                 key = IntPtr.Zero;
             }
@@ -2833,7 +2845,7 @@ namespace wolfSSL.CSharp
                     ivPtr, (uint)iv.Length, authTagPtr, (uint)authTag.Length, addAuthPtr, addAuthSz);
                 if (ret < 0)
                 {
-                    log(ERROR_LOG, "Failed to Encrypt data using AES-GCM. Error code: " + ret);
+                    wolfssl.log(ERROR_LOG, "Failed to Encrypt data using AES-GCM. Error code: " + ret);
                 }
                 else {
                     Marshal.Copy(ciphertextPtr, ciphertext, 0, ciphertext.Length);
@@ -2843,7 +2855,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "AES-GCM Encryption failed: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "AES-GCM Encryption failed: " + e.ToString());
                 ret = EXCEPTION_E;
             }
             finally
@@ -2906,7 +2918,7 @@ namespace wolfSSL.CSharp
                     ivPtr, (uint)iv.Length, authTagPtr, (uint)authTag.Length, addAuthPtr, addAuthSz);
                 if (ret < 0)
                 {
-                    log(ERROR_LOG, "Failed to Decrypt data using AES-GCM. Error code: " + ret);
+                    wolfssl.log(ERROR_LOG, "Failed to Decrypt data using AES-GCM. Error code: " + ret);
                 }
                 else {
                     Marshal.Copy(plaintextPtr, plaintext, 0, plaintext.Length);
@@ -2915,7 +2927,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "AES-GCM Decryption failed: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "AES-GCM Decryption failed: " + e.ToString());
                 ret = EXCEPTION_E;
             }
             finally
@@ -2977,7 +2989,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "HashNew Exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "HashNew Exception: " + e.ToString());
             }
 
             return hash;
@@ -3008,7 +3020,7 @@ namespace wolfSSL.CSharp
             catch (Exception e)
             {
                 /* Cleanup */
-                log(ERROR_LOG, "InitHash Exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "InitHash Exception: " + e.ToString());
                 if (hash != IntPtr.Zero) {
                     wc_HashDelete(hash, IntPtr.Zero);
                     hash = IntPtr.Zero;
@@ -3051,7 +3063,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "HashUpdate Exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "HashUpdate Exception: " + e.ToString());
             }
             finally
             {
@@ -3099,7 +3111,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "HashFinal Exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "HashFinal Exception: " + e.ToString());
                 output = null;
             }
             finally
@@ -3137,7 +3149,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "HashFree Exception: " + e.ToString());
+                wolfssl.log(ERROR_LOG, "HashFree Exception: " + e.ToString());
             }
 
             return ret;
@@ -3168,21 +3180,6 @@ namespace wolfSSL.CSharp
         /* END HASH */
 
 
-        /***********************************************************************
-        * Logging / Other
-        **********************************************************************/
-
-        /// <summary>
-        /// Set the function to use for logging
-        /// </summary>
-        /// <param name="input">Function that conforms as to loggingCb</param>
-        /// <returns>0 on success</returns>
-        public static int SetLogging(loggingCb input)
-        {
-            internal_log = input;
-            return SUCCESS;
-        }
-
         /// <summary>
         /// Get error string for wolfCrypt error codes
         /// </summary>
@@ -3197,7 +3194,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "Get error exception " + e.ToString());
+                wolfssl.log(ERROR_LOG, "Get error exception " + e.ToString());
                 return string.Empty;
             }
         }

--- a/wolfSSLWrapper/wolfSSL.cs
+++ b/wolfSSLWrapper/wolfSSL.cs
@@ -20,10 +20,18 @@
  */
 
 
+/* CE Not always reliably detected. Define our own WindowsCE as needed. */
+#if _WIN32_WCE || WINCE || PocketPC
+    /* WindowsCE should have been defined in the Project and user_settings.h  */
+    #if !WindowsCE
+        #define WindowsCE
+    #endif
+#endif
+
+
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -36,6 +44,156 @@ namespace wolfSSL.CSharp
 
         /* wait for 6 seconds default on TCP socket state poll if timeout not set */
         private const int WC_WAIT = 6000000;
+        private static bool verbose = false;
+
+        /********************************
+         * The WOLFSSL_ALERT_HISTORY
+         */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct WOLFSSL_ALERT
+        {
+            public int code;
+            public int level;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct WOLFSSL_ALERT_HISTORY
+        {
+            public WOLFSSL_ALERT last_rx;
+            public WOLFSSL_ALERT last_tx;
+        }
+
+        public static void SetVerbosity(bool b) {
+            verbose = b;
+        }
+
+        /// <summary>
+        /// Use the SetDllDirectory from Windows kernel32.dll to set DLL location of wolfSSL
+        /// </summary>
+        /// <param name="lpPathName"></param>
+        /// <returns></returns>
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static extern bool SetDllDirectory(string lpPathName);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="p"></param>
+        /// <returns></returns>
+        public static bool LoadDLL(string wolfsslPath) {
+            string baseDir = "";
+            bool ret = false;
+#if WindowsCE
+            string codeBase = System.Reflection.Assembly.GetExecutingAssembly().GetName().CodeBase;
+            string path = codeBase.Replace("file://", "").Replace("/", "\\");
+            string currentDir = System.IO.Path.GetDirectoryName(path);
+            Console.WriteLine("Base Directory: " + currentDir);
+            /*
+             * NOTICE: If you find yourself here as the wolfssl.dll file was not loaded,
+             * there are limited options on a CE Device.
+             *
+             * Please check if:
+             *
+             * 1) The native library wolfssl.dll is not found in the expected path at runtime.
+             * 2) The wolfssl.dll is found, but it is not compatible with the process architecture (e.g., 32-bit vs 64-bit mismatch).
+             * 3) The wolfssl.dll is found, but is missing dependencies (such as a required MSVC runtime or another .dll it links to).
+             *
+             * If everything is ok, try copying the wolfssl.dll file to the target \windows directory.
+             *
+             */
+#else
+            /* Try to find the wolfSSL in all the usual build directories (non-CE platforms only) */
+            string[] subDirsToCheck;
+            if (verbose) {
+                Console.WriteLine("AppDomain.CurrentDomain.BaseDirectory: " + AppDomain.CurrentDomain.BaseDirectory);
+            }
+            bool is64Bit = (IntPtr.Size == 8);
+#if DEBUG
+            if (is64Bit) {
+                subDirsToCheck = new string[] { "Debug", "Debug\\x64" };
+            }
+            else {
+                subDirsToCheck = new string[] { "Debug", "Debug\\x86", "Debug\\Win32" };
+            }
+#elif RELEASE
+            if (is64Bit) {
+                subDirsToCheck = new string[] { "Release", "Release\\x64" };
+            }
+            else {
+                subDirsToCheck = new string[] { "Release", "Release\\x86", "Release\\Win32" };
+            }
+#else
+    #pragma "Only DEBUG and RELEASE supported"
+#endif
+            /* We'll search for alternative locations of a compiled wolfssl.dll only on non-CE targets */
+            if (wolfsslPath == "") {
+                /* wolfSSL project should have created a DLL in [WOLFSSL_ROOT]\Debug, some number of directories up from here:  */
+                /* baseDir = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"..\..\..\..\..\..\Debug")); */
+                string dir = Environment.CurrentDirectory;
+                if (verbose) {
+                    Console.WriteLine("Looking for wolfSSL in parents, starting from: " + dir);
+                }
+
+                while ((!string.IsNullOrEmpty(dir) && Directory.Exists(dir)) || !ret) {
+                    for (int i = 0; i < subDirsToCheck.Length; i++) {
+                        string subdir = Path.Combine(dir, subDirsToCheck[i]);
+                        string candidate = Path.Combine(subdir, wolfssl_dll);
+                        if (verbose) {
+                            Console.WriteLine("Looking in: " + subdir);
+                        }
+                        if (File.Exists(candidate)) {
+                            if (verbose) {
+                                Console.WriteLine("Found wolfssl.dll: " + candidate);
+                            }
+                            /* Be sure to use path without filename in call to SetDllDirectory */
+                            baseDir = subdir;
+                            ret = true;
+                            break;
+                        }
+                    }
+
+                    if (ret) {
+                        break;
+                    }
+
+                    DirectoryInfo parent = Directory.GetParent(dir);
+                    if (parent == null)
+                        break;
+
+                    dir = parent.FullName;
+                }
+
+            }
+            else {
+                baseDir = System.IO.Path.GetDirectoryName(wolfsslPath);
+            }
+            /* end of !WindowsCE directory search */
+#endif
+            /* When in verbose mode, show the details of the wolfssl.dll file being used */
+            if (verbose) {
+                String wolfssl_path = Path.Combine(baseDir, wolfssl_dll);
+                if (File.Exists(wolfssl_path)) {
+                    FileInfo info = new FileInfo(wolfssl_path);
+                    Console.WriteLine("Found: " + wolfssl_path);
+                    Console.WriteLine("  Size: " + info.Length + " bytes");
+                    Console.WriteLine("  Modified: " + info.LastWriteTime.ToString("yyyy-MM-dd HH:mm:ss"));
+                }
+                else {
+                    Console.WriteLine("File not found: " + wolfssl_path);
+                }
+            }
+
+            if (SetDllDirectory(baseDir)) {
+                if (verbose) {
+                    Console.WriteLine("Successfully SetDllDirectory to: " + baseDir);
+                }
+                ret = true;
+            }
+            else {
+                Console.WriteLine("Failed SetDllDirectory for: " + baseDir);
+            }
+            return ret;
+        }
 
         /********************************
          * Utility String Conversion functions
@@ -103,6 +261,21 @@ namespace wolfSSL.CSharp
             return Marshal.PtrToStringAnsi(ptr);
         }
 #endif
+
+        /// <summary>
+        /// All platform Marshal for ASCII string to Multi-byte pointer
+        /// See companion PtrToStringAnsi
+        /// </summary>
+        public static IntPtr StringToAnsiPtr(string str) {
+            if (str == null) {
+                return IntPtr.Zero;
+            }
+
+            byte[] ansiBytes = Encoding.ASCII.GetBytes(str + '\0'); // ensure null-terminated
+            IntPtr ptr = Marshal.AllocHGlobal(ansiBytes.Length);
+            Marshal.Copy(ansiBytes, 0, ptr, ansiBytes.Length);
+            return ptr;
+        }
 
 
         /********************************
@@ -300,7 +473,6 @@ namespace wolfSSL.CSharp
                 }
             }
         }
-
 
         /********************************
          * Init wolfSSL library
@@ -554,7 +726,7 @@ namespace wolfSSL.CSharp
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private extern static int wolfSSL_set_cipher_list(IntPtr ssl, StringBuilder ciphers);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private extern static int wolfSSL_get_ciphers(StringBuilder ciphers, int sz);
+        private extern static int wolfSSL_get_ciphers(string ciphers, int sz);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private extern static IntPtr wolfSSL_get_cipher(IntPtr ssl);
         [DllImport(wolfssl_dll, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
@@ -575,28 +747,43 @@ namespace wolfSSL.CSharp
         private extern static IntPtr wolfSSL_ERR_reason_error_string(uint err);
         [DllImport(wolfssl_dll)]
         private extern static int wolfSSL_get_error(IntPtr ssl, int err);
+        [DllImport(wolfssl_dll)]
+        private extern static int wolfSSL_get_alert_history(IntPtr ssl, ref WOLFSSL_ALERT_HISTORY h);
+        /* No decorator needed for loggingCb, Note msg is String here, not StringBuilder */
         public delegate void loggingCb(int lvl, string msg);
+        /* No decorator needed for loggingCbEx */
+        public delegate void loggingCbEx(int lvl, IntPtr msg);
         [DllImport(wolfssl_dll)]
         private extern static void wolfSSL_Debugging_ON();
         [DllImport(wolfssl_dll)]
         private extern static void wolfSSL_Debugging_OFF();
         [DllImport(wolfssl_dll)]
         private extern static int wolfSSL_SetLoggingCb(loggingCb vc);
+
+        /* Internal field to store the original logging callback: string msg */
+        private static loggingCb internal_log;
 #else
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
         private extern static IntPtr wolfSSL_ERR_reason_error_string(uint err);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private extern static int wolfSSL_get_error(IntPtr ssl, int err);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private extern static int wolfSSL_get_alert_history(IntPtr ssl, ref WOLFSSL_ALERT_HISTORY h);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void loggingCb(int lvl, StringBuilder msg);
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void loggingCbEx(int level, IntPtr msg);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private extern static void wolfSSL_Debugging_ON();
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private extern static void wolfSSL_Debugging_OFF();
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private extern static int wolfSSL_SetLoggingCb(loggingCb vc);
+        private extern static int wolfSSL_SetLoggingCb(loggingCbEx vc);
+
+        /* Internal fields to store the non-CE logging callback; StringBuilder msg */
+        private static loggingCbEx internal_log_ex         = null; /* keep reference to prevent GC         */
+        private static loggingCbEx internal_bridge_cb      = null; /* helper when using original loggingCb */
 #endif
-        private static loggingCb internal_log;
 
         /********************************
          * DH
@@ -612,9 +799,9 @@ namespace wolfSSL.CSharp
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private extern static int wolfSSL_CTX_SetMinDhKey_Sz(IntPtr ctx, short size);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private extern static int wolfSSL_SetTmpDH_file(IntPtr ssl, StringBuilder dhParam, int type);
+        private extern static int wolfSSL_SetTmpDH_file(IntPtr ssl, string dhParam, int type);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private extern static int wolfSSL_CTX_SetTmpDH_file(IntPtr ctx, StringBuilder dhParam, int type);
+        private extern static int wolfSSL_CTX_SetTmpDH_file(IntPtr ctx, string dhParam, int type);
 
 #endif
 
@@ -743,15 +930,37 @@ namespace wolfSSL.CSharp
             }
         }
 
+#if WindowsCE
+        /* implement a Directory.GetParent(dir) helper for CE only */
+        public static string GetParentDirectory(string path) {
+            if (string.IsNullOrEmpty(path))
+                return string.Empty;
+
+            string normalized = path.TrimEnd('\\');
+
+            int lastSeparator = normalized.LastIndexOf('\\');
+            if (lastSeparator > 0)
+                return normalized.Substring(0, lastSeparator);
+            else
+                return string.Empty; // No parent exists
+        }
+#endif
+
         /// <summary>
         /// Utility function used to access the certificates
         /// based on the platform.
         /// <returns>return the platform specific path to the certificate</returns>
         /// </summary>
-        public static string setPath(string file) {
+        public static string setPath(string file)
+        {
             PlatformID platform = Environment.OSVersion.Platform;
+            string cert_path = "./";
+            string current_dir = ".";
+            bool found_path = false;
 
-#if !WindowsCE
+#if WindowsCE
+            /* Skip this first check for CE, as Unix and MacOSX platforms are not defined  */
+#else
             if (platform == PlatformID.Unix ||
                 platform == PlatformID.MacOSX)
             {
@@ -765,10 +974,36 @@ namespace wolfSSL.CSharp
                 platform == PlatformID.Win32S ||
                 platform == PlatformID.WinCE)
             {
+                current_dir = Directory.GetCurrentDirectory();
+                while (!string.IsNullOrEmpty(current_dir) && !found_path)
+                {
+                    cert_path = Path.Combine(current_dir, "certs");
+                    if (Directory.Exists(cert_path))
+                    {
+                        Console.WriteLine("Found certs folder at: " + cert_path);
+                        found_path = true;
+                    }
+
+                    if (string.IsNullOrEmpty(current_dir))
+                    {
+                        current_dir = ".\\";
+                    }
+                    else
+                    {
+#if WindowsCE
+                        current_dir = GetParentDirectory(current_dir);
+#else
+                        current_dir = Directory.GetParent(current_dir).FullName;
+#endif
+                    }
+                } /* while */
+
                 Console.WriteLine("Windows - " + file);
-                return @"../../../../certs/" + file;
-            } else
+                return cert_path + "\\" + file;
+            }
+            else
             {
+                Console.WriteLine("Other environment: " + platform.ToString() + ", no cert file found.");
                 return "";
             }
         }
@@ -1580,11 +1815,11 @@ namespace wolfSSL.CSharp
                     return FAILURE;
                 }
 
-            #if WindowsCE
+#if WindowsCE
                 return wolfSSL_CTX_use_psk_identity_hint(local_ctx, wolfssl.WideCharToMultiByte(hint));
-            #else
+#else
                 return wolfSSL_CTX_use_psk_identity_hint(local_ctx, hint);
-            #endif
+#endif
             }
             catch (Exception e)
             {
@@ -1862,20 +2097,16 @@ namespace wolfSSL.CSharp
         {
             try
             {
-            #if WindowsCE
                 string ciphers = new string(' ', 4096);
-            #else
-                StringBuilder ciphers = new StringBuilder(new String(' ', 4096));
-            #endif
                 int ret = wolfSSL_get_ciphers(ciphers, ciphers.Length);
                 if (ret != SUCCESS)
                     return null;
 
-        #if WindowsCE
+#if WindowsCE
                 return wolfssl.MultiByteToWideChar(ciphers);
-        #else
+#else
                 return ciphers.ToString();
-        #endif
+#endif
             }
             catch (Exception e)
             {
@@ -1890,11 +2121,7 @@ namespace wolfSSL.CSharp
         /// <param name="list">list to fill with cipher suite names</param>
         /// <param name="sz">size of list available to fill</param>
         /// <returns>1 on success</returns>
-#if WindowsCE
         public static int get_ciphers(string list, int sz)
-#else
-        public static int get_ciphers(StringBuilder list, int sz)
-#endif
         {
             try
             {
@@ -2044,6 +2271,7 @@ namespace wolfSSL.CSharp
             catch (Exception e)
             {
                 log(ERROR_LOG, "wolfssl error " + e.ToString());
+                Console.WriteLine(e.Message);
                 return IntPtr.Zero;
             }
         }
@@ -2142,11 +2370,11 @@ namespace wolfSSL.CSharp
                     return FAILURE;
                 }
 
-            #if WindowsCE
+#if WindowsCE
                 return wolfSSL_CTX_set_cipher_list(local_ctx, wolfssl.WideCharToMultiByte(list));
-            #else
+#else
                 return wolfSSL_CTX_set_cipher_list(local_ctx, list);
-            #endif
+#endif
             }
             catch (Exception e)
             {
@@ -2177,11 +2405,11 @@ namespace wolfSSL.CSharp
                     return FAILURE;
                 }
 
-            #if WindowsCE
+#if WindowsCE
                 return wolfSSL_set_cipher_list(sslCtx, wolfssl.WideCharToMultiByte(list));
-            #else
+#else
                 return wolfSSL_set_cipher_list(sslCtx, list);
-            #endif
+#endif
             }
             catch (Exception e)
             {
@@ -2258,6 +2486,32 @@ namespace wolfSSL.CSharp
 
 
         /// <summary>
+        /// This function gets the alert history.
+        /// </summary>
+        /// <param name="ssl">SSL struct</param>
+        /// <param name="h">a pointer to a WOLFSSL_ALERT_HISTORY structure that will hold the WOLFSSL struct’s alert_history member’s value.</param>
+        /// <returns>Integer result of wolfSSL_get_alert_history SSL_SUCCESS or FAILURE</returns>
+        public static int get_alert_history(IntPtr ssl, ref WOLFSSL_ALERT_HISTORY h) {
+            if (ssl == IntPtr.Zero)
+                return FAILURE;
+
+            try {
+                IntPtr local_ssl = unwrap_ssl(ssl);
+                if (local_ssl == IntPtr.Zero) {
+                    log(ERROR_LOG, "wolfssl get_error error");
+                    return FAILURE;
+                }
+
+                return wolfSSL_get_alert_history(local_ssl, ref h);
+            }
+            catch (Exception e) {
+                log(ERROR_LOG, "wolfssl get error, error " + e.ToString());
+                return FAILURE;
+            }
+        }
+
+
+        /// <summary>
         /// Used to load in the certificate file
         /// </summary>
         /// <param name="ctx">CTX structure for TLS/SSL connections</param>
@@ -2275,11 +2529,11 @@ namespace wolfSSL.CSharp
                     return FAILURE;
                 }
 
-            #if WindowsCE
+#if WindowsCE
                 return wolfSSL_CTX_use_certificate_file(local_ctx, wolfssl.WideCharToMultiByte(fileCert), type);
-            #else
+#else
                 return wolfSSL_CTX_use_certificate_file(local_ctx, fileCert, type);
-            #endif
+#endif
             }
             catch (Exception e)
             {
@@ -2307,11 +2561,11 @@ namespace wolfSSL.CSharp
                     return FAILURE;
                 }
 
-            #if WindowsCE
+#if WindowsCE
                 return wolfSSL_CTX_load_verify_locations(local_ctx, wolfssl.WideCharToMultiByte(fileCert), wolfssl.WideCharToMultiByte(path));
-            #else
+#else
                 return wolfSSL_CTX_load_verify_locations(local_ctx, fileCert, path);
-            #endif
+#endif
             }
             catch (Exception e)
             {
@@ -2338,11 +2592,11 @@ namespace wolfSSL.CSharp
                     return FAILURE;
                 }
 
-            #if WindowsCE
+#if WindowsCE
                 return wolfSSL_CTX_use_PrivateKey_file(local_ctx, wolfssl.WideCharToMultiByte(fileKey), type);
-            #else
+#else
                 return wolfSSL_CTX_use_PrivateKey_file(local_ctx, fileKey, type);
-            #endif
+#endif
             }
             catch (Exception e)
             {
@@ -2359,11 +2613,7 @@ namespace wolfSSL.CSharp
         /// <param name="dhparam">file name</param>
         /// <param name="file_type">type of file ie PEM</param>
         /// <returns>1 on success</returns>
-#if WindowsCE
         public static int SetTmpDH_file(IntPtr ssl, string dhparam, int file_type)
-#else
-        public static int SetTmpDH_file(IntPtr ssl, StringBuilder dhparam, int file_type)
-#endif
         {
             try
             {
@@ -2374,11 +2624,11 @@ namespace wolfSSL.CSharp
                     return FAILURE;
                 }
 
-            #if WindowsCE
+#if WindowsCE
                 return wolfSSL_SetTmpDH_file(sslCtx, wolfssl.WideCharToMultiByte(dhparam), file_type);
-            #else
+#else
                 return wolfSSL_SetTmpDH_file(sslCtx, dhparam, file_type);
-            #endif
+#endif
             }
             catch (Exception e)
             {
@@ -2394,11 +2644,7 @@ namespace wolfSSL.CSharp
         /// <param name="dhparam">file name</param>
         /// <param name="file_type">type of file ie PEM</param>
         /// <returns>1 on success</returns>
-#if WindowsCE
         public static int CTX_SetTmpDH_file(IntPtr ctx, string dhparam, int file_type)
-#else
-        public static int CTX_SetTmpDH_file(IntPtr ctx, StringBuilder dhparam, int file_type)
-#endif
         {
             try
             {
@@ -2409,11 +2655,11 @@ namespace wolfSSL.CSharp
                     return FAILURE;
                 }
 
-            #if WindowsCE
+#if WindowsCE
                 return wolfSSL_CTX_SetTmpDH_file(local_ctx, wolfssl.WideCharToMultiByte(dhparam), file_type);
-            #else
+#else
                 return wolfSSL_CTX_SetTmpDH_file(local_ctx, dhparam, file_type);
-            #endif
+#endif
             }
             catch (Exception e)
             {
@@ -2639,19 +2885,47 @@ namespace wolfSSL.CSharp
         }
 
         /// <summary>
-        /// Set the function to use for logging
+        /// Clean up old callbacks if previously assigned.
         /// </summary>
-        /// <param name="input">Function that conforms as to loggingCb</param>
+        public static void ClearLoggingCallbacks() {
+            /* Delegates are managed objects; nulling the reference allows GC to clean up. */
+#if WindowsCE
+            internal_log = null;
+            wolfSSL_SetLoggingCb((loggingCb)null); /* call wolfSSL callback cleanup, string param */
+#else
+            internal_log_ex = null;
+            internal_bridge_cb = null;
+            wolfSSL_SetLoggingCb((loggingCbEx)null); /* call wolfSSL callback cleanup */
+#endif
+        }
+
+        /* SetLogging() and log() implementations are different for CE vs non-CE: String msg vs StringBuilder msg */
+#if WindowsCE
+        /// <summary>
+        /// Set the function to use for logging on Windows CE
+        /// </summary>
+        /// <param name="input">Function that conforms as to loggingCb String msg</param>
         /// <returns>1 on success</returns>
         public static int SetLogging(loggingCb input)
         {
+            /* If SetLogging was previously called, clean it up and exit if there's no new cb function */
+            if (input == null) {
+                ClearLoggingCallbacks();
+                return SetLogging((loggingCb)null);
+            }
+
+            /* If SetLogging is called with a new logging function, clean up the old one first: */
+            if (internal_log != null) {
+                ClearLoggingCallbacks();
+            }
+
+            /* Set our new callback logging function */
             internal_log = input;
 
             wolfSSL_SetLoggingCb(input);
 
             return SUCCESS;
         }
-
 
         /// <summary>
         /// Log a message to set logging function
@@ -2661,14 +2935,104 @@ namespace wolfSSL.CSharp
         public static void log(int lvl, string msg)
         {
             /* if log is not set then print nothing */
-            if (internal_log == null)
+            if (internal_log == null) {
                 return;
-        #if WindowsCE
+            }
             internal_log(lvl, msg);
-        #else
-            StringBuilder msg_sb = new StringBuilder(msg);
-            internal_log(lvl, msg_sb);
-        #endif
         }
-    }
-}
+#else
+        /// <summary>
+        /// Set the function to use for logging
+        /// </summary>
+        /// <param name="input">Function that conforms as to loggingCb StringBuilder msg</param>
+        /// <returns>1 on success</returns>
+        public static int SetLogging(loggingCb input)
+        {
+            /* If SetLogging was previously called, clean it up and exit if there's no new cb function */
+            if (input == null) {
+                ClearLoggingCallbacks();
+                return SetLogging((loggingCbEx)null);
+            }
+
+            /* If SetLogging is called with a new logging function, clean up the old one first: */
+            if (internal_bridge_cb != null) {
+                ClearLoggingCallbacks();
+            }
+
+            /* Build a bridge that routes through internal_log_ex logic */
+            internal_bridge_cb = new loggingCbEx(delegate (int lvl, IntPtr msgPtr)
+            {
+                string msg;
+
+                if (msgPtr == IntPtr.Zero) {
+                    msg = "";
+                }
+                else {
+                    int len = 0;
+                    while (Marshal.ReadByte(msgPtr, len) != 0) {
+                        len++;
+                    }
+
+                    byte[] buffer = new byte[len];
+                    Marshal.Copy(msgPtr, buffer, 0, len);
+                    msg = Encoding.ASCII.GetString(buffer, 0, buffer.Length);
+                }
+
+                StringBuilder sb = new StringBuilder();
+                sb.Append(msg);
+
+                input(lvl, sb);
+            });
+
+            /* return the result of SetLogging(loggingCbEx input) */
+            return SetLogging(internal_bridge_cb);
+        }
+
+        /// <summary>
+        /// Set the function to use for logging
+        /// </summary>
+        /// <param name="input">Function that conforms as to loggingCb for preferred IntPtr msg</param>
+        /// <returns>1 on success</returns>
+        public static int SetLogging(loggingCbEx input) {
+            if (input == null) {
+                ClearLoggingCallbacks();
+                return wolfSSL_SetLoggingCb((loggingCbEx)null);
+            }
+
+            /* If SetLogging is called with a new logging function, clean up the old one first: */
+            if (internal_log_ex != null) {
+                ClearLoggingCallbacks();
+            }
+
+            internal_log_ex = input;
+
+            /* Return the result of the native call to wolfSSL */
+            return wolfSSL_SetLoggingCb(input);
+        }
+
+        /// <summary>
+        /// Log a message to set logging function
+        /// </summary>
+        /// <param name="lvl">Level of log message</param>
+        /// <param name="msg">Message to log</param>
+        public static void log(int lvl, string msg)
+        {
+            /* if log is not set then print nothing; has SetLogging been called? */
+            if (internal_log_ex == null) {
+                return;
+            }
+
+            IntPtr ptr = wolfssl.StringToAnsiPtr(msg);
+            try
+            {
+                internal_log_ex(lvl, ptr);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(ptr);
+            }
+        }
+#endif
+
+    } /* class wolfssl */
+} /* namespace wolfSSL.CSharp */


### PR DESCRIPTION
@AbishekSindhe 
This improves the MultiByte <-> WideChar conversion routines.
Fixes issue in `wolfssl.get_error`
Updates from https://github.com/wolfSSL/wolfssl/pull/8799

Added example for overriding a begin date error. Work upstreamed here: https://github.com/wolfSSL/wolfssl/pull/8903